### PR TITLE
Fix loclistoffset_eq

### DIFF
--- a/src/dwarf2.c
+++ b/src/dwarf2.c
@@ -1120,7 +1120,7 @@ loclistoffset_eq (const void *p, const void *q)
   GElf_Addr *offset1 = (GElf_Addr *)p;
   GElf_Addr *offset2 = (GElf_Addr *)q;
 
-  return *offset1 = *offset2;
+  return *offset1 == *offset2;
 }
 
 static void


### PR DESCRIPTION
Not all DWARF loclists were being updated because loclistoffset_eq performed an assignment instead of checking for equality.